### PR TITLE
Align buildable ground dimensions with full build area

### DIFF
--- a/simcity-web-starter/src/main.ts
+++ b/simcity-web-starter/src/main.ts
@@ -69,7 +69,7 @@ let currentIsoZoom = 1.0
 
 // Convert screen coordinates to world coordinates with grid snapping
 function screenToWorld(screenX: number, screenY: number, snapToGrid: boolean = false): { x: number, z: number } {
-  const GRID_SIZE = 1000
+  const GRID_SIZE = 2000
   const aspect = window.innerWidth / window.innerHeight
 
   // Convert to NDC space (-1 to 1)
@@ -90,9 +90,9 @@ function screenToWorld(screenX: number, screenY: number, snapToGrid: boolean = f
   const worldX = (Y / scale) + (aspect / (sqrt3 * scale)) * X
   const worldZ = (Y / scale) - (aspect / (sqrt3 * scale)) * X
 
-  // Convert from render coordinates (-500..500) to procgen coordinates (0..2000)
-  const finalX = (worldX + GRID_SIZE / 2) * 2
-  const finalZ = (worldZ + GRID_SIZE / 2) * 2
+  // Convert from render coordinates (-1000..1000) to procgen coordinates (0..2000)
+  const finalX = worldX + GRID_SIZE / 2
+  const finalZ = worldZ + GRID_SIZE / 2
 
   if (snapToGrid) {
     const gridSize = 40

--- a/simcity-web-starter/src/workers/render.worker.ts
+++ b/simcity-web-starter/src/workers/render.worker.ts
@@ -84,12 +84,12 @@ let basicShader: WebGLProgram | null = null
 let buildingShader: WebGLProgram | null = null
 
 // Grid/ground
-const GRID_SIZE = 1000
+const GRID_SIZE = 2000
 const GRID_DIVISIONS = 100
 
-// Convert procgen coordinates (0..2000) to renderer coords (-500..500)
+// Convert procgen coordinates (0..2000) to renderer coords (-1000..1000)
 function toRenderCoord(value: number): number {
-  return value * 0.5 - GRID_SIZE / 2
+  return value - GRID_SIZE / 2
 }
 
 // Isometric camera state
@@ -902,7 +902,7 @@ function updateZoneMesh(data: any) {
     
     // Add vertices for the parcel polygon
     for (const vert of parcelVerts) {
-      // Convert from procgen coordinates (0-2000) to render coordinates (-500 to 500)
+      // Convert from procgen coordinates (0-2000) to render coordinates (-1000 to 1000)
       const x = toRenderCoord(vert.x)
       const z = toRenderCoord(vert.y)
       


### PR DESCRIPTION
## Summary
- Expand ground grid to 2km square so grass buildable area matches full map
- Update coordinate conversion to map 0–2000 build space to new renderer scale

## Testing
- `npm test` *(fails: Missing script "test")*
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68ae5a401428832dbf4a8e605718d8a5